### PR TITLE
Fixed argument to --filter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function getWorkspaces(from) {
 
     for (const w of workspaces) {
         const workspacePkgInfo = JSONFile.for(path.join(w, 'package.json'));
-        const workspaceName = path.parse(w).name;
+        const workspaceName = `ghost/${path.parse(w).name}`;
 
         if (!workspacePkgInfo.pkg.private) {
             continue;

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ function getWorkspaces(from) {
 
     for (const w of workspaces) {
         const workspacePkgInfo = JSONFile.for(path.join(w, 'package.json'));
+        const workspaceName = path.parse(w).name;
 
         if (!workspacePkgInfo.pkg.private) {
             continue;
@@ -120,7 +121,7 @@ function getWorkspaces(from) {
         pkgInfo.pkg.resolutions[workspacePkgInfo.pkg.name] = packedFilename;
 
         console.log(`packaging ${w}`);
-        await ultraRunner.run(['' /* placeholder */, '' /* placeholder */, '--filter', w, '-r', 'npm', 'pack', '--pack-destination', '../core/components']);
+        await ultraRunner.run(['' /* placeholder */, '' /* placeholder */, '--filter', workspaceName, '-r', 'npm', 'pack', '--pack-destination', '../core/components']);
     }
 
     pkgInfo.write();


### PR DESCRIPTION
The `w` variable referred to the full path of the package, rather than the directory name. `path.parse` will pull out the name for us, which will play nicely with ultrarunner